### PR TITLE
Updates documentation to reflect current setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
-tiltify-api is a [NodeCG](http://github.com/nodecg/nodecg) bundle. 
-It works with NodeCG versions which satisfy this [semver](https://docs.npmjs.com/getting-started/semantic-versioning) range: `^1.1.1`
+`nodecg-tiltify` is a [NodeCG](http://github.com/nodecg/nodecg) bundle. It works with NodeCG versions which satisfy this [semver](https://docs.npmjs.com/getting-started/semantic-versioning) range: `^1.1.1`
+
 You will need to have an appropriate version of NodeCG installed to use it.
 
+## Setup
 
-This bundle sets up a Replicant in the `tiltify-api` namespace, called `donations`.  It contains all of the donations that we've seen from the Tiltify API. It does NOT use pagination to get donations past the current "page". It also exposes a Replicant called `total` in the same namespace that shows how much Tiltify says we've raised so far!
+1. Add `nodecg-tiltify` to your [`nodecg.dependencies`](https://nodecg.com/docs/manifest/#nodecgbundledependencies) in your bundle's package.json
+2. [Create an application for your Tiltify account](https://tiltify.github.io/api/topics/getting-started.html)
+3. Take the Access Token from your application and add the following to `nodecg/cfg/nodecg-tiltify.json`:
 
-Each element in `donations` is given a `read` and `shown` property. Typically, I would use these to determine if a donation has been `shown` on whatever `graphic` you're trying to show it on, and to mark whether or not is has been `read` on whatever `dashboard` you're presenting donations to be read on.
-
-A donation object has an `amount`, a `name`, a `comment`, use them to do with them what you will. 
-
-You need to set up the config in `cfg/tiltify-api.json` to look something like this:
 ```
 {
 	"tiltify_api_key": "KEY_HERE",
@@ -17,3 +15,23 @@ You need to set up the config in `cfg/tiltify-api.json` to look something like t
 }
 ```
 
+## Details
+
+This bundle sets up [`NodeCG.Replicant`](https://nodecg.com/docs/classes/replicant/) objects in the `nodecg-tiltify` namespace.
+
+Available Replicants from the Tiltify API:
+- [X] `donations`\*
+- [X] `alldonations`\*\*
+- [X] `total`
+- [X] `donationpolls`
+- [X] `schedule`
+- [X] `donations`
+- [X] `challenges`
+- [X] `rewards`
+- [ ] `campaign`: (Coming soon)
+
+The replicants convert results from the Tiltify API into objects, and more information on the exact format of the data from these replicants can be found in the [Tiltify API docs](https://tiltify.github.io/api/).
+
+\*`donations` objects contain the additional properties `read` and `shown` which can be used to indicate if something was read in the dashboard or shown in a graphic. `donations` also only collects donations from the most recent 'page' of the Tiltify API.
+
+\*\*`alldonations` contains all donations that have been made.


### PR DESCRIPTION
- Corrects a few mistakes with setup, mostly `tiltify-api` -> `nodecg-tiltify`
- Clarifies specific setup steps
- Clarifies where to find more information about replicant values